### PR TITLE
Paginate results that are longer than 50 results

### DIFF
--- a/src/webapp/_styles/explore.less
+++ b/src/webapp/_styles/explore.less
@@ -718,6 +718,27 @@ div.same-as.row {
 		padding-left: 1.5em;
 		padding-right: 0.25em;
 	}
+  &.inverse {
+		>.predicate {
+			&:before {
+				content: "is ";
+				font-size: 9pt;
+				padding-right: 0.25em;
+			}
+		}
+
+		&>.values-cell {
+	    	font-size: 0.85em;
+
+			&:before {
+				content: "of";
+			    display: inline;
+			    position: absolute;
+			    margin-left: -2em;
+			    font-size: 9pt;
+			}
+		}
+	}
 }
 
 .values-cell {


### PR DESCRIPTION
This PR adds pagination on the node landing pages. It removes the previous chunking feature, which downloaded extra results in chunks of ~50. This change introduces event handlers on the scroll areas that look for events where users scroll to the bottom. One there, the next batch of queries are sent. This adds back the _inverse_ _of_ tags on incoming triples.