### PR TITLE
Serve content off of /static instead of /assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,31 @@ This is the repository for phuzzylink in KWG .
 
 ## Deploying
 
-To deploy the service:
-```npm install```
-```npx emk```
-```node src/server/server.js -p 3001```
+Before starting the server, first install the dependencies and run the npx build tool.
+
+```
+npm install
+cd plugins
+npm install
+cd ..
+npx emk
+```
+
+### Production and Development
+To deploy on a production server or locally use,
+
+`node src/server/server.js -p 3001`
+
+### Staging
+When deploying to staging, specify the endpoint using the `-e` flag,
+
+`node src/server/server.js -e https://staging.knowwheregraph.org/graphdb/repositories/KWG -p 3001`
+
+### Backgrounding the Process
+
+When deploying on remote servers, you may want to run the process in the background so that you can exit ssh without stopping the process. To do this, use `nohup`
+
+`nohup node src/server/server.js -p 3001 &`
 
 ## Developing
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -46,7 +46,6 @@ const P_ENDPOINT = h_argv.e || h_argv.endpoint || 'https://stko-kwg.geog.ucsb.ed
 
 const P_DIR_PLUGINS = path.resolve(__dirname, '../..', 'plugins');
 const P_DIR_FETCH = path.resolve(__dirname, '../..', 'fetch');
-const P_DIR_DATA = path.resolve(__dirname, '../..', 'data');
 
 const X_MAX_PAYLOAD_SIZE = 16384;
 
@@ -149,23 +148,9 @@ function resolve_endpoint(s_endpoint, d_res) {
 	return s_endpoint;
 }
 
-
 const k_app = express();
-
-
 const PD_ROOT = path.resolve(__dirname, '../../');
-
-const PD_LIB = path.join(PD_ROOT, 'src');
-const PD_LIB_WEBAPP = path.join(PD_LIB, 'webapp');
-
-// there are no files named as '_resources'
-const PD_RESOURCES = path.join(PD_LIB_WEBAPP, '_resources');
-
-const PD_DIST = path.join(PD_ROOT, 'build');
-const PD_DIST_WEBAPP = path.join(PD_DIST, 'webapp');
-
 const SCHEMA_BASE_DIR = path.join('static', 'schema');
-
 const R_SAFE_PATH = /^[\w-]+$/;
 
 function assert_safe_path(s_file, d_res) {
@@ -173,7 +158,6 @@ function assert_safe_path(s_file, d_res) {
 		d_res.status(400).end(`bad param name: '${s_file}'`);
 	}
 }
-
 
 // middleware body parse
 k_app.use(body_parser.json({
@@ -187,33 +171,19 @@ k_app.use(cors());
 k_app.set('views', path.resolve(__dirname, '../webapp/_layouts'));
 k_app.set('view engine', 'pug');
 
-// styles
-k_app.use('/asset/style', less_middleware(path.join(PD_LIB_WEBAPP, '_styles'), {
-	dest: path.join(PD_DIST_WEBAPP, '_styles'),
-}));
-
-// // scripts
+// scripts
 browserify_middleware.settings.development('minify', true);
 browserify_middleware.settings.development('gzip', true);
-k_app.use('/asset/script', browserify_middleware(__dirname+'/../webapp/_scripts'));
+k_app.use('/static/script', browserify_middleware(__dirname+'/../webapp/_scripts'));
 
 // static routing
-// k_app.use('/script', express.static(__dirname+'/../../build/webapp/_scripts'));
-k_app.use('/asset/style', express.static(__dirname+'/../../build/webapp/_styles'));
-// Updated by Rui
-//k_app.use('/asset/resource', express.static(__dirname+'/../../src/webapp/_resources'));
-k_app.use('/asset/resource', express.static(__dirname+'/../../plugins/node_modules/leaflet/dist'));
-k_app.use('/asset/fonts', express.static(__dirname+'/../../node_modules/font-awesome/fonts'));
-k_app.use('/asset/data', express.static(P_DIR_DATA));
-
-// // static routing from ios press interface
+k_app.use('/static/style', express.static(__dirname+'/../../build/webapp/_styles'));
+k_app.use('/static/resource', express.static(__dirname+'/../../plugins/node_modules/leaflet/dist'));
 k_app.use('/static/css', express.static(path.join(PD_ROOT, 'static/css')));
 k_app.use('/static/js', express.static(path.join(PD_ROOT, 'static/js')));
 k_app.use('/static/images', express.static(path.join(PD_ROOT, 'static/images')));
 k_app.use('/static/schema', express.static(path.join(PD_ROOT, SCHEMA_BASE_DIR)));
-k_app.use('/asset', express.static(path.join(PD_ROOT, 'static/asset')));
 
-//
 k_app.get('/', (d_req, d_res) => {
 	d_res.sendFile(path.join(PD_ROOT, 'static/html/index.html'));
 });
@@ -231,6 +201,7 @@ const D_URL_ENDPOINT = new url.URL(P_ENDPOINT);
 // sparql
 k_app.use('/sparql', proxy({
 	target: D_URL_ENDPOINT.origin,
+  secure: false,
 	pathRewrite: {
 		'^/sparql': D_URL_ENDPOINT.pathname,
 	},

--- a/src/webapp/_layouts/explore.pug
+++ b/src/webapp/_layouts/explore.pug
@@ -5,16 +5,16 @@ html(lang='en')
     title KnowWhereGraph
     link(rel='stylesheet', type='text/css', href='/static/css/style.css')
     link(rel="stylesheet", type='text/css', href='/static/css/general.css')
-    link(rel='stylesheet', type='text/css', href='/asset/style/explore.css')
-    link(rel='stylesheet', type='text/css', href='/asset/resource/leaflet.css')
+    link(rel='stylesheet', type='text/css', href='/static/style/explore.css')
+    link(rel='stylesheet', type='text/css', href='/static/resource/leaflet.css')
     link(rel='shortcut icon', href='/favicon.png')
     link(rel='stylesheet', type='text/css', href='//fonts.googleapis.com/css?family=PT+Sans:400,700%7CPT+Serif:400,700')
     link(rel='stylesheet prefetch', href='//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css')
     //- changed common to general (Rui) - /css/common.css controls the header dropdown menus
     //-link(rel='stylesheet', href='/css/common.css')
     link(rel='stylesheet', href='https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css')
-    link(rel='stylesheet', type='text/css', href='/asset/style/explore_header.css')
-    script(src='/asset/script/explore.js')
+    link(rel='stylesheet', type='text/css', href='/static/style/explore_header.css')
+    script(src='/static/script/explore.js')
 
   body
     .body-content


### PR DESCRIPTION
This PR fixes the issue described in issue #38.

To test:
1. Deploy locally
2. Visit http://localhost:3001/browse/#kwgr:Earth.North_America.United_States.USA.38_1
3. Make sure that the page looks the same as it does on production (nothing broke)