### PR TITLE
Add support for kwg-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@ This is the repository for phuzzylink in KWG .
 ## Deploying
 
 To deploy the service:
-```npm install```
-```npx emk```
-```node src/server/server.js -p 3001```
+`npm install`
+
+`cd ./plugins`
+
+`npm install`
+
+`cd ..`
+
+`npx emk`
+
+`node src/server/server.js -p 3001`
 
 ## Developing
 

--- a/src/main/phuzzy.js
+++ b/src/main/phuzzy.js
@@ -397,9 +397,12 @@ class ResourceChannel {
 				}
 			}
 		};
-
+		let endpoint = this.phuzzy.endpoint;
+		if (window.location.href.includes("kwgl")) {
+			endpoint = this.phuzzy.lite_endpoint;
+		}
 		// open async http post request to endpoint
-		d_xhr.open('POST', this.phuzzy.endpoint, true);
+		d_xhr.open('POST', endpoint, true);
 
 		// headers
 		d_xhr.setRequestHeader('Accept', S_MIME_SPARQL_RESULTS);
@@ -2027,7 +2030,6 @@ class Phuzzy {
 		// source
 		let d_source = this.space.querySelector('.outgoing .browse-header .source');
 		d_source.classList.remove('ready');
-		d_source.classList.add('loading');
 
 		// instantiate new resource loader
 		this.loader = new ResourceLoader(p_resource, this, () => {
@@ -2037,8 +2039,6 @@ class Phuzzy {
 			});
 
 			// rdf display
-			d_source.classList.remove('loading');
-			d_source.classList.add('ready');
 			$(d_source).unbind()
 				.click(function() {
 					k_machine.toggle();

--- a/src/main/phuzzy.js
+++ b/src/main/phuzzy.js
@@ -398,8 +398,12 @@ class ResourceChannel {
 			}
 		};
 		let endpoint = this.phuzzy.endpoint;
+
 		if (window.location.href.includes("kwgl")) {
 			endpoint = this.phuzzy.lite_endpoint;
+		}
+		if (window.location.href.includes("kwgl") && window.location.href.includes("staging.")) {
+			endpoint = this.phuzzy.lite_endpoint_staging;
 		}
 		// open async http post request to endpoint
 		d_xhr.open('POST', endpoint, true);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -42,7 +42,7 @@ const proxy = require('http-proxy-middleware');
 
 const N_PORT = h_argv.p || h_argv.port || 80;
 const P_ENDPOINT = h_argv.e || h_argv.endpoint || 'https://stko-kwg.geog.ucsb.edu/graphdb/repositories/KWG';
-
+const P_LITE_ENDPOINT = h_argv.e || h_argv.endpoint || 'https://stko-kwg.geog.ucsb.edu/graphdb/repositories/KWG-Lite'
 
 const P_DIR_PLUGINS = path.resolve(__dirname, '../..', 'plugins');
 const P_DIR_FETCH = path.resolve(__dirname, '../..', 'fetch');
@@ -230,6 +230,7 @@ const D_URL_ENDPOINT = new url.URL(P_ENDPOINT);
 
 // sparql
 k_app.use('/sparql', proxy({
+	changeOrigin: true,
 	target: D_URL_ENDPOINT.origin,
 	pathRewrite: {
 		'^/sparql': D_URL_ENDPOINT.pathname,
@@ -246,26 +247,10 @@ const H_PREFIXES = {
 	dc: 'http://purl.org/dc/elements/1.1/',
 	dcterms: 'http://purl.org/dc/terms/',
 	foaf: 'http://xmlns.com/foaf/0.1/',
-
-
-	//kwgr: 'http://stko-roy.geog.ucsb.edu/lod/resource/',
 	kwgr: 'http://stko-kwg.geog.ucsb.edu/lod/resource/',
 	'kwg-ont':'http://stko-kwg.geog.ucsb.edu/lod/ontology/',
-	//directrelief: 'https://stko-directrelief.geog.ucsb.edu/lod/ontology/' ,
-	//'dr-affiliation': 'https://stko-directrelief.geog.ucsb.edu/lod/affiliation/' ,
-    //'dr-people': 'https://stko-directrelief.geog.ucsb.edu/lod/people/' ,
-	//'dr-expertise': 'https://stko-directrelief.geog.ucsb.edu/lod/expertise/' ,
-	//'dr-place': 'https://stko-directrelief.geog.ucsb.edu/lod/place/' ,
-
-	// iospress: 'http://ld.iospress.nl/rdf/ontology/',
-	// 'iospress-category': 'http://ld.iospress.nl/rdf/category/',
-	// 'iospress-datatype': 'http://ld.iospress.nl/rdf/datatype/',
-	// 'iospress-index': 'http://ld.iospress.nl/rdf/index/',
-	// 'iospress-alias': 'http://ld.iospress.nl/rdf/alias/',
-	// 'iospress-artifact': 'http://ld.iospress.nl/rdf/artifact/',
-	// 'iospress-contributor': 'http://ld.iospress.nl/rdf/contributor/',
-	// 'iospress-organization': 'http://ld.iospress.nl/rdf/organization/',
-	// 'iospress-geocode': 'http://ld.iospress.nl/rdf/geocode/',
+	'kwgl-ont':'http://stko-kwg.geog.ucsb.edu/lod/lite-ontology/',
+	'kwglr': 'http://stko-kwg.geog.ucsb.edu/lod/lite-resource/',
 	geo: 'http://www.opengis.net/ont/geosparql#',
 	ago: 'http://awesemantic-geo.link/ontology/',
 };
@@ -276,8 +261,8 @@ for(let [s_prefix_id, p_prefix_iri] of Object.entries(H_PREFIXES)) {
 }
 
 // submit sparql query via HTTP
-const sparql_query = (s_accept, s_query, fk_query) => {
-	request.post(P_ENDPOINT, {
+const sparql_query = (s_accept, s_query, fk_query, endpoint=P_ENDPOINT) => {
+	request.post(endpoint, {
 		headers: {
 			accept: s_accept,
 			'content-type': 'application/sparql-query;charset=UTF-8',
@@ -327,6 +312,12 @@ const negotiate_feature = (d_req, d_res, f_next) => {
 		d_res.redirect(p_redirect);
 	};
 
+	// If the subject is coming from the lite repository-switch endpoints
+	let endpoint = P_ENDPOINT
+	if (group.includes("kwgl")) {
+		endpoint = P_LITE_ENDPOINT;
+	}
+
 	// application/rdf+xml
 	let f_rdf_xml = () => {
 		sparql_query('application/rdf+xml', `describe ${sv1_entity}`, (e_query, d_sparql_res, s_res_body) => {
@@ -341,27 +332,8 @@ const negotiate_feature = (d_req, d_res, f_next) => {
 
 			// otherwise; send body
 			d_res.send(s_res_body);
-		});
+		}, endpoint);
 	};
-
-	// // json-ld
-	// let f_json_ld = () => {
-	// 	sparql_query('application/ld+json', `describe ${sv1_entity}`, (e_query, d_sparql_res, s_res_body) => {
-	// 		// response mime type
-	// 		d_res.type('application/');
-
-	// 		// response status code
-	// 		d_res.statusCode = e_query? 500: d_sparql_res.statusCode;
-
-	// 		// head only; don't send body
-	// 		if(b_head_only) return d_res.end();
-
-	// 		// otherwise; send body
-	// 		jsonld.toRDF(JSON.parse(s_res_body), {format:'application/nquads'}, (e_parse, s_nquads) => {
-	// 			d_res.send(s_nquads);
-	// 		});
-	// 	});
-	// };
 
 	// content negotiation
 	d_req.negotiate({
@@ -404,7 +376,7 @@ const negotiate_feature = (d_req, d_res, f_next) => {
 
 		html: f_redirect,
 		default: f_rdf_xml,
-	});
+	}, endpoint);
 };
 
 
@@ -639,7 +611,8 @@ k_app.get([
 					//'kwg-ont':'http://stko-roy.geog.ucsb.edu/lod/ontology/',
 					kwgr: 'http://stko-kwg.geog.ucsb.edu/lod/resource/',
 					'kwg-ont':'http://stko-kwg.geog.ucsb.edu/lod/ontology/',
-
+					'kwgl-ont':'http://stko-kwg.geog.ucsb.edu/lod/lite-ontology/',
+					'kwglr': 'http://stko-kwg.geog.ucsb.edu/lod/lite-resource/',
 					sosa: 'http://www.w3.org/ns/sosa/',
 					time: 'http://www.w3.org/2006/time#',
 

--- a/src/webapp/_layouts/explore.pug
+++ b/src/webapp/_layouts/explore.pug
@@ -77,8 +77,7 @@ html(lang='en')
                 span.access(style="display:none;")
                   span.text RDF source
                   span.icon.fa.fa-code
-                span.spinner
-                  span.icon.fa.fa-spin.fa-circle-o-notch
+
             #machine.hide
               div#rdf-format
                 div.graphy

--- a/src/webapp/_scripts/explore.js
+++ b/src/webapp/_scripts/explore.js
@@ -155,6 +155,7 @@ function extract_resource(s_from, b_initial=false) {
 
 				// prefix not exist
 				if(!h_prefixes[s_prefix]) {
+					console.log(h_prefixes)
 					throw new Error(`no such prefix found in context: ${s_prefix}`);
 				}
 
@@ -431,6 +432,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 				// all good
 				d_endpoint.classList.add('okay');
+				console.log("OK")
 				fk_task();
 			});
 		},
@@ -541,6 +543,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		// load prefixes
 		(fk_task) => {
+			console.log("Loading prefixes")
 			// prefixes is given by a url to a json-ld file
 			if('string' === typeof z_prefixes) {
 				// // turn path into absolute URI
@@ -696,6 +699,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				k_explorer = phuzzy({
 					prefixes: h_prefixes,
 					endpoint: p_endpoint,
+					lite_endpoint: P_ENDPOINT,
 					plugins: a_init_plugins,
 					settings: h_settings,
 					sort_order: a_sort_order.map((s_rule) => {
@@ -716,7 +720,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				else {
 					k_explorer.browse('<http://ld.iospress.nl/rdf/organization/Publisher.IOS_Press>');
 				}
-
+				console.log("Done")
 				// done here
 				fk_task();
 			});
@@ -746,4 +750,5 @@ document.addEventListener('DOMContentLoaded', () => {
 			k_explorer.browse(p_resource);
 		}, false);
 	});
+	
 });

--- a/src/webapp/_scripts/explore.js
+++ b/src/webapp/_scripts/explore.js
@@ -699,7 +699,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				k_explorer = phuzzy({
 					prefixes: h_prefixes,
 					endpoint: p_endpoint,
-					lite_endpoint: P_ENDPOINT,
+					lite_endpoint: "https://stko-kwg.geog.ucsb.edu/graphdb/repositories/KWG-Lite",
+					lite_endpoint_staging: "https://staging.knowwheregraph.org/graphdb/repositories/KWG-Lite",
 					plugins: a_init_plugins,
 					settings: h_settings,
 					sort_order: a_sort_order.map((s_rule) => {

--- a/src/webapp/_scripts/query.js
+++ b/src/webapp/_scripts/query.js
@@ -230,6 +230,7 @@ const H_PREFIXES = {
 	cegis: 'http://data.usgs.gov/lod/cegis/ontology/',
 	cegisf: 'http://data.usgs.gov/lod/cegis/feature/',
 	'umbel-rc': 'http://umbel.org/umbel/rc/',
+	'kwglr': 'http://stko-kwg.geog.ucsb.edu/lod/lite-resource/',
 };
 
 const R_SELECTOR = /^(\w*)(.*)$/;

--- a/src/webapp/_styles/explore.less
+++ b/src/webapp/_styles/explore.less
@@ -291,13 +291,6 @@ div.same-as.row {
 					margin-top: 7pt;
 					font-size: 10pt;
 
-					&>.spinner {
-						display: inline-flex;
-						width: 20pt;
-						transition: width 0.5s;
-						overflow: hidden;
-						font-size: 16pt;
-					}
 
 					&>.access {
 						padding-top: 0;
@@ -349,9 +342,7 @@ div.same-as.row {
 							// }
 						}
 
-						&>.spinner {
-							width: 0;
-						}
+
 					}
 				}
 			}


### PR DESCRIPTION
Adds functionality for talking to kwg-lite when the subject is coming from the kwg-lite repo.

Bit of a snafu trying to get the endpoint configurable. It needs to get passed from the server file to the "explore" controller(? not actually sure if 'explore.js' is a controller). This is slightly different than what currently happens with the normal endpoint-which is the server decided to use an endpoint at startup (the endpoint defined [here](https://github.com/KnowWhereGraph/phuzzylink/compare/kwg-lite?expand=1#diff-f85e295b34c9835cd9f4b308ba1deea8fc648cb706ae7d4e198cf3585051dee1R44) and rewrites the /sparql path. From then on-all requests are sent to /sparql - so 'explore.js' and other files don't need to actually know the full graphdb repository path.

In our case, we need to switch the endpoint at runtime (so no proxy rewrite). It's pretty hacky - but we store two endpoints (one for stage, one for prod) and store them in the `phuzzy` object where it gets called in the explore controller. 

I also removed the broken spinner

Screenshot of it in action

![Screenshot from 2023-04-09 08-13-59](https://user-images.githubusercontent.com/9289652/230782802-fc87d65c-503c-4ea3-8a17-fa9af375fded.png)
